### PR TITLE
Add 'resourcedetection' processor by default - pod identity & other useful labels

### DIFF
--- a/helmchart/otel-add-on/values.yaml
+++ b/helmchart/otel-add-on/values.yaml
@@ -160,6 +160,19 @@ opentelemetry-collector:
       opencensus:
         endpoint: 0.0.0.0:55678
         include_metadata: true
+
+    processors:
+      resourcedetection/env:
+        detectors: [ env ]
+        timeout: 2s
+        override: false
+      transform:
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["namespace"], resource.attributes["k8s.namespace.name"])
+              - set(attributes["pod"], resource.attributes["k8s.pod.name"])
+              - set(attributes["deployment"], resource.attributes["k8s.deployment.name"])
     exporters:
       otlp:
         # make sure this is the same hostname and port as .service (when using different namespace)
@@ -175,11 +188,9 @@ opentelemetry-collector:
         - health_check
       pipelines:
         metrics:
-          receivers:
-            - opencensus
-          exporters:
-            - debug
-            - otlp
+          receivers: [opencensus]
+          processors: [resourcedetection/env, transform]
+          exporters: [debug, otlp]
 
     extensions:
       health_check:


### PR DESCRIPTION
fix Issue #73 

This PR adds some k8s labels for each metric.

In the following setup:
```mermaid
graph TD;
    replica1--fooMetric{code=200}-->OTelAddon;
    replica2--fooMetric{code=200}-->OTelAddon;
   OTelAddon<-->KEDA
```
The measured value of `fooMetric{code=200}` metric from both pods will end up in the same 'logical place' in the scaler's metric store. Then averages or sums across all the labels doesn't make much sense, because we can't tell which value came from which pod.

Instead we want something like this:
```mermaid
graph TD;
    replica1--fooMetric{code=200,pod=replica1}-->OTelAddon;
    replica2--fooMetric{code=200,pod=replica2}-->OTelAddon;
   OTelAddon<-->KEDA
```
Then following metric query - `sum(fooMetric)`  works as it should, i.e. sum of those values over all the possible labels