### PR TITLE
Create VAPs only when k8s has the crd

### DIFF
--- a/helmchart/otel-add-on/templates/vap.yaml
+++ b/helmchart/otel-add-on/templates/vap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.validatingAdmissionPolicy.enabled -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
@@ -43,4 +44,5 @@ metadata:
 spec:
   policyName: "well-formed-otel-scalers"
   validationActions: [Deny]
+{{- end }}
 {{- end }}


### PR DESCRIPTION
older k8s (like `<= 1.29.x`) has this resource in `v1beta1 `