### PR TITLE
Don't use Chart.Name in templates

### DIFF
--- a/examples/metric-pull/setup.sh
+++ b/examples/metric-pull/setup.sh
@@ -38,6 +38,8 @@ kubectl apply -f ${DIR}/podinfo-so.yaml
 (hey -n 7000 -z 180s http://localhost:8181/delay/2 &> /dev/null)&
 
 # watch deployments being scaled
-echo "hey is running in background, now deployments should be autoscaled.."
+echo -e "\nhey is running in background, now deployments should be autoscaled.."
 sleep 5
 watch -c "kubectl get deploy/podinfo"
+
+echo -e "\nDon't forget to delete the cluster:\n - k3d cluster delete metric-pull\n\n🚀"

--- a/examples/metric-push/setup.sh
+++ b/examples/metric-push/setup.sh
@@ -66,3 +66,5 @@ kubectl apply -f ${DIR}/sos.yaml
 echo "now deployments should be autoscaled.."
 sleep 5
 watch -c "kubectl get deploy/recommendation deploy/product-catalog hpa/keda-hpa-recommendationservice hpa/keda-hpa-productcatalogservice"
+
+echo -e "\nDon't forget to delete the cluster:\n - k3d cluster delete metric-push\n\n🚀"

--- a/helmchart/otel-add-on/templates/_helpers.tpl
+++ b/helmchart/otel-add-on/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "otel-add-on.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default "otel-add-on" .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -14,7 +14,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default "otel-add-on" .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "otel-add-on.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" "otel-add-on" .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/helmchart/otel-add-on/templates/deployment.yaml
+++ b/helmchart/otel-add-on/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: main
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
..because when consumed as sub-chart and renamed in Chart.yaml using alias, it may cause some k8s resources failed to render because of various k8s constraints applied to naming