### PR TITLE
Support for counter resets

### DIFF
--- a/metric/mem_store.go
+++ b/metric/mem_store.go
@@ -307,11 +307,13 @@ func calculateRate(data []t.ObservedValue) float64 {
 		return 0
 	}
 
-	timeDelta := float64(data[len(data)-1].Time - data[0].Time)
-	if timeDelta <= 0 {
+	firstTime := data[0].Time
+	lastTime := data[len(data)-1].Time
+	if lastTime <= firstTime {
 		return 0
 	}
 
+	timeDelta := float64(lastTime - firstTime)
 	var valuesDelta float64
 	prev := data[0].Value
 	for i := 1; i < len(data); i++ {

--- a/metric/mem_store.go
+++ b/metric/mem_store.go
@@ -286,9 +286,7 @@ func (m ms) updateAggregatesOverTime(md *t.MetricData, metricName t.MetricName) 
 func (m ms) updateAggregationOverTime(overTime t.OperationOverTime, md *t.MetricData) {
 	switch overTime {
 	case t.OpRate:
-		valuesDelta := md.Data[len(md.Data)-1].Value - md.Data[0].Value
-		timeDelta := float64(md.Data[len(md.Data)-1].Time - md.Data[0].Time)
-		md.AggregatesOverTime.Store(t.OpRate, valuesDelta/timeDelta)
+		md.AggregatesOverTime.Store(t.OpRate, calculateRate(md.Data))
 	case t.OpMin, t.OpMax, t.OpAvg:
 		acc, _ := md.AggregatesOverTime.Load(overTime)
 		for i := 0; i < len(md.Data); i++ {
@@ -302,6 +300,33 @@ func (m ms) updateAggregationOverTime(overTime t.OperationOverTime, md *t.Metric
 	default:
 		panic("unknown aggregation over time function: " + overTime)
 	}
+}
+
+func calculateRate(data []t.ObservedValue) float64 {
+	if len(data) < 2 {
+		return 0
+	}
+
+	timeDelta := float64(data[len(data)-1].Time - data[0].Time)
+	if timeDelta <= 0 {
+		return 0
+	}
+
+	var valuesDelta float64
+	prev := data[0].Value
+	for i := 1; i < len(data); i++ {
+		current := data[i].Value
+		if current >= prev {
+			valuesDelta += current - prev
+		} else {
+			// Counter reset detected. Treat the current sample as the increase
+			// accumulated since the reset back to zero.
+			valuesDelta += current
+		}
+		prev = current
+	}
+
+	return valuesDelta / timeDelta
 }
 
 func (m ms) GetStore() *t.Map[string, *t.Map[t.LabelsHash, *t.MetricData]] {

--- a/metric/mem_store_lazy_test.go
+++ b/metric/mem_store_lazy_test.go
@@ -150,8 +150,8 @@ func TestLazyMemStoreAndLazyAggregatesComplex(t *testing.T) {
 	assertNotThere(t, ms, name, labels, ty.OpRate, ty.VecSum)
 	now += 100
 	setupMetricsWithNow(ms, now, name, 10, labels, 20., 30., 40., 50., 600.)
-	// (600 - 6) / (600 - 360) - 6. is the first value, 600 the last one and 240 is the delta in time of measurements
-	assertMetricFoundAndEqualTo(t, ms, name, labels, ty.OpRate, ty.VecSum, 2.475)
+	// Rate uses counter semantics, so the 10 -> 1 drop is treated as a reset.
+	assertMetricFoundAndEqualTo(t, ms, name, labels, ty.OpRate, ty.VecSum, 2.516)
 
 	// count
 	assertNotThere(t, ms, name, labels, ty.OpCount, ty.VecSum)

--- a/metric/mem_store_test.go
+++ b/metric/mem_store_test.go
@@ -523,6 +523,20 @@ func TestMemStoreRateOverTimeForgetOld(t *testing.T) {
 	assertMetricFound(t, val, found, err, 1.)
 }
 
+func TestMemStoreRateOverTimeCounterReset(t *testing.T) {
+	// setup
+	ms := newMetricStore(200, false, false)
+	labels := map[string]any{
+		"a": "1",
+	}
+	name := "m3t/r1c"
+	setupMetrics(ms, name, 10, labels, 1., 3., 4., 6., 7., 9., 10., 0., 1.)
+
+	// check
+	val, found, err := ms.Get(ty.MetricName(name), labels, ty.OpRate, ty.VecSum)
+	assertMetricFound(t, val, found, err, .125)
+}
+
 func TestMemStoreSumOverAverages(t *testing.T) {
 	// setup
 	ms := newMetricStore(60, false, false)

--- a/types/metrics.go
+++ b/types/metrics.go
@@ -57,8 +57,8 @@ const (
 	// OpLastOne returns the last measured value
 	OpLastOne OperationOverTime = "last_one"
 
-	// OpRate calculates the per-second growth. Suitable for monotonic time series and is calculated as
-	// delta between last and first measured element divided by overTimePeriodSeconds
+	// OpRate calculates the per-second growth. Suitable for monotonic time series and handles
+	// counter resets by summing positive deltas over the stored time window.
 	OpRate  OperationOverTime = "rate"
 	OpCount OperationOverTime = "count"
 	OpAvg   OperationOverTime = "avg"


### PR DESCRIPTION
Fix #191

If a reset in a monotonic serie is detected, the rate is calculated from the new minimum (breaking point). It's a rare event, but client libraries for generating metrics have a way to reset counters. Or if the app gets restarted..